### PR TITLE
Add Timeout for cURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The result is class **Result** and contain methods:
 * ClientBase lite function
 * Form Proxmox VE 6.2 support Api Token for user
 * Login with One-time password for Two-factor authentication.
+* Set Timeout for the Connection.
 
 ## Api token
 
@@ -157,6 +158,9 @@ if($client->login('root','password','pam')){
   //result json result
   $client->setResponseType('json');
   var_dump($client->get('/version')->getResponse());
+  
+  //set connection timeout (by default no timeout)
+  $client->setTimeout(2)->get('/version')->getResponse();
 }
 
 ```

--- a/src/PveClientBase.php
+++ b/src/PveClientBase.php
@@ -17,10 +17,10 @@ class PveClientBase
 {
 
     /**
-     * Set default of the timeout to 32 seconds.
+     * Set default to 0 ... which means no timeout limit at all
      * @ignore
      */
-    private $timeoutInMs = 32000;
+    private $timeout = 0;
 
     /**
      * @ignore
@@ -79,27 +79,20 @@ class PveClientBase
     }
 
     /**
-     * In Favor of convenience we can set the Timeout in Seconds as well.
-     * @return void
+     * Set timeout in seconds
+     * @return $this
      */
-    public function setTimeout($timeout_in_s) {
-        $this->timeoutInMs = $timeout_in_s * 1000;
+    public function setTimeout($timeout) {
+        $this->timeout = $timeout;
+        return $this;
     }
 
     /**
-     * Set the Timeout in MS value
-     * @return void
-     */
-    public function setTimeoutInMs($timeout) {
-        $this->timeoutInMs = $timeout;
-    }
-
-    /**
-     * Get the Timeout in MS
+     * Get timeout in seconds.
      * @return int
      */
-    public function getTimeoutInMs() {
-        return $this->timeoutInMs;
+    public function getTimeout() {
+        return $this->timeout;
     }
 
 
@@ -373,9 +366,12 @@ class PveClientBase
         curl_setopt($prox_ch, CURLOPT_SSL_VERIFYHOST, false);
 
         /**
-         * Set the Timeout for the Request in curl | CURLOPT_TIMEOUT_MS sets the maximum execution time of the cUrl function.
+         * Set the Timeout for the Request in curl | CURLOPT_TIMEOUT sets the maximum execution time of the cUrl function.
          */
-        curl_setopt($prox_ch, CURLOPT_TIMEOUT_MS, $this->getTimeoutInMs());
+        $timeout = $this->timeout;
+        if($timeout != 0) {
+            curl_setopt($prox_ch, CURLOPT_TIMEOUT, $timeout);
+        }
 
         if (isset($this->ticketPVEAuthCookie)) {
             array_push($headers, "CSRFPreventionToken: {$this->ticketCSRFPreventionToken}");

--- a/src/PveClientBase.php
+++ b/src/PveClientBase.php
@@ -17,6 +17,12 @@ class PveClientBase
 {
 
     /**
+     * Set default of the timeout to 32 seconds.
+     * @ignore
+     */
+    private $timeoutInMs = 32000;
+
+    /**
      * @ignore
      */
     private $ticketCSRFPreventionToken;
@@ -71,6 +77,31 @@ class PveClientBase
         $this->hostname = $hostname;
         $this->port = $port;
     }
+
+    /**
+     * In Favor of convenience we can set the Timeout in Seconds as well.
+     * @return void
+     */
+    public function setTimeout($timeout_in_s) {
+        $this->timeoutInMs = $timeout_in_s * 1000;
+    }
+
+    /**
+     * Set the Timeout in MS value
+     * @return void
+     */
+    public function setTimeoutInMs($timeout) {
+        $this->timeoutInMs = $timeout;
+    }
+
+    /**
+     * Get the Timeout in MS
+     * @return int
+     */
+    public function getTimeoutInMs() {
+        return $this->timeoutInMs;
+    }
+
 
     /**
      * Return if result is object
@@ -340,6 +371,11 @@ class PveClientBase
         curl_setopt($prox_ch, CURLOPT_COOKIE, "PVEAuthCookie=" . $this->ticketPVEAuthCookie);
         curl_setopt($prox_ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($prox_ch, CURLOPT_SSL_VERIFYHOST, false);
+
+        /**
+         * Set the Timeout for the Request in curl | CURLOPT_TIMEOUT_MS sets the maximum execution time of the cUrl function.
+         */
+        curl_setopt($prox_ch, CURLOPT_TIMEOUT_MS, $this->getTimeoutInMs());
 
         if (isset($this->ticketPVEAuthCookie)) {
             array_push($headers, "CSRFPreventionToken: {$this->ticketCSRFPreventionToken}");

--- a/tests/test.php
+++ b/tests/test.php
@@ -25,6 +25,9 @@ if ($client->login($argv[2], $argv[3], "pam")) {
         echo "\n" . $node->id;
     }
 
+    /* Timeout test 2 seconds */
+    var_dump($client->setTimeout(2)->getVersion()->version()->getResponse());
+
     $client->getNodes()->get("cc01")->getQemu()->get(1006)->getAgent()->getExec()->exec(array("powershell", "-command", "echo", "test"));
 
     // foreach ($client->getNodes()->get("cv-pve01")->getQemu()->vmlist()->getResponse()->data as $vm) {


### PR DESCRIPTION
- Added documentation.
- Added test.
- `setTimeout()` returns now $this for support of method-chaining.
-  Instead of `CURLOPT_TIMEOUT_MS` now using `CURLOPT_TIMEOUT` for compatibility.
-  No Timeout by default.