### PR TITLE
Add responseHeaders field to Result class

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The result is class **Result** and contain methods:
 * **getReasonPhrase()** (string): The reason phrase which typically is sent by servers together with the status code.
 * **isSuccessStatusCode()** (bool) : Gets a value that indicates if the HTTP response was successful.
 * **getError()** (string) : Get error.
+* **getResponseHeaders()** (string) : Gets the raw HTTP headers associated with this response.
 
 ## Main features
 

--- a/src/PveClientBase.php
+++ b/src/PveClientBase.php
@@ -439,6 +439,7 @@ class PveClientBase
         unset($prox_ch);
 
         $body = substr($response, $curlInfo["header_size"]);
+        $responseHeaders = substr($response, 0, $curlInfo["header_size"]);
         unset($response);
         unset($curlInfo);
 
@@ -465,7 +466,8 @@ class PveClientBase
             $resource,
             $parameters,
             $methodType,
-            $this->responseType
+            $this->responseType,
+            $responseHeaders,
         );
 
         if (is_array($this->onActionExecuted) && count($this->onActionExecuted)) {

--- a/src/Result.php
+++ b/src/Result.php
@@ -56,6 +56,11 @@ class Result
     /**
      * @ignore
      */
+    private $responseHeaders;
+
+    /**
+     * @ignore
+     */
     public function __construct(
         $response,
         $statusCode,
@@ -64,7 +69,8 @@ class Result
         $requestResource,
         $requestParameters,
         $methodType,
-        $responseType
+        $responseType,
+        $responseHeaders
     ) {
         $this->statusCode = $statusCode;
         $this->reasonPhrase = $reasonPhrase;
@@ -74,6 +80,7 @@ class Result
         $this->requestParameters = $requestParameters;
         $this->methodType = $methodType;
         $this->responseType = $responseType;
+        $this->responseHeaders = $responseHeaders;
     }
 
     /**
@@ -137,6 +144,15 @@ class Result
     public function getReasonPhrase()
     {
         return $this->reasonPhrase;
+    }
+
+    /**
+     * Gets the raw HTTP headers associated with this response.
+     * @return string
+     */
+    public function getResponseHeaders()
+    {
+        return $this->responseHeaders;
     }
 
     /**


### PR DESCRIPTION
This change adds a `responseHeaders` field to the `Result` class, which contains the raw HTTP headers for a response. The main motivation here is that PVE API can sometimes put error messages in the headers, instead of in the JSON response body.