### PR TITLE
added missing query (parameters) to URL in DELETE method

### DIFF
--- a/src/PveClientBase.php
+++ b/src/PveClientBase.php
@@ -404,6 +404,14 @@ class PveClientBase
             case "DELETE":
                 curl_setopt($prox_ch, CURLOPT_CUSTOMREQUEST, "DELETE");
                 $methodType = "DELETE";
+
+                // do not forget to pass query from params if there are any
+                if (count($params) > 0) {
+                    $action_postfields = http_build_query($params);
+                    $url .= '?' . $action_postfields;
+                    unset($action_postfields);
+                }
+
                 break;
 
             default:


### PR DESCRIPTION
DELETE method in PveClientBase::executeAction() had missing query in URL which is optionally expected sometimes, eg. in PVEStorageStorageNodeNodesPrunebackups::delete($prune_backups = null, $type = null, $vmid = null). Without this update delete() behavior cannot be influenced anyhow.

I have copied the same lines from GET method handling its URL query.

Can you merge this update it to master, please?