### PR TITLE
chore: bump version to 9.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "corsinvest/cv4pve-api-php",
     "description": "Corsinvest Proxmox VE Client API PHP",
-    "version": "9.1.0",
+    "version": "9.2.0",
     "keywords": [
         "Proxmox",
         "Proxmox VE",

--- a/src/PveClientBase.php
+++ b/src/PveClientBase.php
@@ -541,13 +541,10 @@ class PveClientBase
             $timeOut = $wait + 5000;
         }
         $timeStart = floor(microtime(true) * 1000);
-        $waitTime = floor(microtime(true) * 1000);
 
         while ($isRunning && ((floor(microtime(true) * 1000) - $timeStart) < $timeOut)) {
-            if ((floor(microtime(true) * 1000) - $waitTime) >= $wait) {
-                $waitTime = floor(microtime(true) * 1000);
-                $isRunning = $this->taskIsRunning($task);
-            }
+            $isRunning = $this->taskIsRunning($task);
+            usleep($wait * 1000);
         }
 
         return $isRunning;


### PR DESCRIPTION
## Summary

- Bump version from `9.1.0` to `9.2.0` in `composer.json`
- Simplify `waitForTaskToFinish` loop in `PveClientBase.php`: replace manual time-tracking variable with `usleep` for a cleaner and more standard wait approach

## Test plan

- [ ] Verify `composer.json` version is `9.2.0`
- [ ] Verify task wait loop behaves correctly with `usleep`