### PR TITLE
ci: add release workflow for tag-based GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Validate version
+      id: version
+      run: |
+        # Extract version from composer.json
+        PROJECT_VERSION=$(php -r "echo json_decode(file_get_contents('composer.json'))->version;")
+        echo "Project version: $PROJECT_VERSION"
+        # Extract version from tag
+        TAG_VERSION=${GITHUB_REF#refs/tags/v}
+        echo "Tag version: $TAG_VERSION"
+        # Validate they match
+        if [ "$PROJECT_VERSION" != "$TAG_VERSION" ]; then
+          echo "❌ ERROR: Version mismatch!"
+          echo "   composer.json: $PROJECT_VERSION"
+          echo "   Git tag: v$TAG_VERSION"
+          exit 1
+        fi
+        echo "✅ Version validated: $PROJECT_VERSION"
+        echo "version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
+
+    - name: Create release
+      uses: softprops/action-gh-release@v2
+      with:
+        name: Release v${{ steps.version.outputs.version }}
+        draft: false
+        prerelease: false
+        generate_release_notes: true
+
+    # Packagist auto-updates via the GitHub webhook/integration once the
+    # release tag is pushed, so no explicit publish step is required.


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that, on pushing a `v*` tag, validates the `composer.json` version against the tag and creates a GitHub Release with auto-generated notes.

## Why
Mirrors the JavaScript repo's publish workflow, adapted for PHP/Packagist. Since Packagist auto-updates the package via its GitHub integration when a release tag is pushed, **no explicit publish step is needed** — the workflow only handles version validation and release creation.

## Flow
1. Push tag `vX.Y.Z`
2. Workflow checks the tag matches `composer.json` version (fails otherwise)
3. Creates the GitHub Release with generated notes
4. Packagist picks up the new tag automatically